### PR TITLE
developers can call, show, add, edit, and delete training programs, p…

### DIFF
--- a/app/controllers/training_programs_controller.rb
+++ b/app/controllers/training_programs_controller.rb
@@ -53,4 +53,6 @@ class TrainingProgramsController < ApplicationController
     def training_program_params
         params.permit(:program_name, :start_date_time, :end_date_time, :attendee_max)
     end
+
+    
 end

--- a/app/controllers/training_programs_controller.rb
+++ b/app/controllers/training_programs_controller.rb
@@ -34,12 +34,13 @@ class TrainingProgramsController < ApplicationController
     end
 
 
-    # PUT CONDITION TO ONLY ALLOW IF....
-    # START DATE IS IN THE FUTURE
-
     # DELETE /training_programs/1
     def destroy
-        @training_program.destroy
+        if @training_program.start_date_time > DateTime.now
+            @training_program.destroy
+        else
+            raise "Cannot delete programs that have already started"
+        end
     end
 
     private
@@ -50,6 +51,6 @@ class TrainingProgramsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def training_program_params
-        params.fetch(:training_program, {})
+        params.permit(:program_name, :start_date_time, :end_date_time, :attendee_max)
     end
 end

--- a/app/models/training_program.rb
+++ b/app/models/training_program.rb
@@ -1,5 +1,13 @@
 class TrainingProgram < ApplicationRecord
 
+	validates :program_name, :start_date_time, :end_date_time, :attendee_max, presence: true
     has_and_belongs_to_many :employees
+    validate :end_date_time_after_start_date_time
+
+    def end_date_time_after_start_date_time
+        if end_date_time < start_date_time
+        	errors.add :end_date_time, "Whoah, buckaroo, it can't start after it ends."
+        end
+    end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20171023212024) do
 
   create_table "computers", force: :cascade do |t|


### PR DESCRIPTION
…rotected from deleting training programs in the past

## Status
**READY**

## Migrations
NO

## Description
Developers can show all, show one, and edit training programs
Developers can only delete a training program if start date and time is in the future

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
```
git fetch origin jw-training-program
git checkout jw-training-program
rails db:reset
```

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
1. GET training_programs
should pass
2. GET training_programs/1
should pass
3. POST training_programs
should pass  /  
3.1 POST training_programs w/o name, date, and attendee fields 
should fail
3.2 POST training_programs w/ end date before start date
should fail
4. PATCH training_programs/1
should pass
5. DELETE training_programs/1
should fail if start_date_time > now
6. DELETE training_programs/1
should pass if start_date_time < now

## Impacted Areas in Application
List general components of the application that this PR will affect:

* 
