### PR TITLE
Ml order crud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'faker', '~> 1.7', '>= 1.7.2'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     arel (8.0.0)
     builder (3.2.3)
     byebug (9.1.0)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.2)
     erubi (1.7.0)
@@ -69,6 +70,9 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    pry (0.11.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     puma (3.10.0)
     rack (2.0.3)
     rack-test (0.7.0)
@@ -129,6 +133,7 @@ DEPENDENCIES
   byebug
   faker (~> 1.7, >= 1.7.2)
   listen (>= 3.0.5, < 3.2)
+  pry
   puma (~> 3.7)
   rails (~> 5.1.4)
   spring

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -36,10 +36,15 @@ class OrdersController < ApplicationController
 
     # PATCH/PUT /orders/1
     def update
-        if @order.update(order_params)
-            render json: @order
+        @customer = Customer.find(@order.customer_id)
+        if @customer.check_pt?(order_params[:payment_type_id])
+            if @order.update(order_params)
+                render json: @order
+            else
+                render json: @order.errors, status: :unprocessable_entity
+            end
         else
-            render json: @order.errors, status: :unprocessable_entity
+            raise "Payment Type not associated with customer.... buckaroo"
         end
     end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -15,13 +15,23 @@ class OrdersController < ApplicationController
 
     # POST /orders
     def create
-        @order = Order.new(order_params)
+        @customer = Customer.find(order_params[:customer_id])
+        if @customer.check_pt?(order_params[:payment_type_id])
 
-        if @order.save
-            render json: @order, status: :created, location: @order
+            @order = Order.new(order_params)
+    
+            @order.amount_paid = 0.00
+    
+            if @order.save
+                render json: @order, status: :created, location: @order
+            else
+                render json: @order.errors, status: :unprocessable_entity
+            end
+
         else
-            render json: @order.errors, status: :unprocessable_entity
+            raise "Payment Type not associated with customer.... buckaroo"
         end
+
     end
 
     # PATCH/PUT /orders/1
@@ -46,6 +56,6 @@ class OrdersController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def order_params
-        params.fetch(:order, {})
+        params.permit(:customer_id, :payment_type_id)
     end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,5 +1,7 @@
 class Customer < ApplicationRecord
 
+    require 'pry'
+
     has_many :products
 
     has_many :orders
@@ -9,11 +11,31 @@ class Customer < ApplicationRecord
     validates :first_name, :last_name, :presence => true
 
     def check_pt?(pt)
+
         if self.payment_types.ids.include?(pt.to_i)
+
             true
+
         else
+
             false
+
         end
+
     end 
+
+     def check_customer_open_order_status?(order)
+
+        unopen_order = true
+
+        order.each do |o|
+            if o.amount_paid == 0.0
+                unopen_order = false
+            end
+        end
+
+        return unopen_order
+        
+    end
 
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,5 +1,7 @@
 class Customer < ApplicationRecord
 
+    require 'pry'
+
     has_many :products
 
     has_many :orders
@@ -7,5 +9,14 @@ class Customer < ApplicationRecord
     has_many :payment_types
 
     validates :first_name, :last_name, :presence => true
+
+    def check_pt?(pt)
+        # binding.pry
+        if self.payment_types.ids.include?(pt.to_i)
+            true
+        else
+            false
+        end
+    end 
 
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,7 +1,5 @@
 class Customer < ApplicationRecord
 
-    require 'pry'
-
     has_many :products
 
     has_many :orders
@@ -11,7 +9,6 @@ class Customer < ApplicationRecord
     validates :first_name, :last_name, :presence => true
 
     def check_pt?(pt)
-        # binding.pry
         if self.payment_types.ids.include?(pt.to_i)
             true
         else

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,11 +1,27 @@
 class Order < ApplicationRecord
 
+    require 'pry'
+
     has_many :customers
 
     has_many :payment_types
 
     has_and_belongs_to_many :products
 
-    validates :customer_id, presence: true, uniqueness: true
+    validates :customer_id, presence: true
+    
+    def order_total_price(op)
+        # binding.pry
+        if op.empty?
+            return 0.00
+        else
+            price = 0.00
+            op.each do |p|
+                # product = Product.find(p)
+                price += p.price
+            end
+            return price
+        end
+    end
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,4 +6,6 @@ class Order < ApplicationRecord
 
     has_and_belongs_to_many :products
 
+    validates :customer_id, presence: true, uniqueness: true
+
 end


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Added CRUD functionality for Orders where customer_id must be present and payment_type_id must be associated with the correct customer. 

## Todos
- [ ] Tests
- [ ] Documentation

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch origin ml-order-crud
git checkout ml-order-crud
bundle install
rails db:reset
```

GET, POST, PATCH,  DELETE functionality:

GET: Ability to get single order by id or all orders

POST: Ability to add order to Orders only if:
1. customer_id is NOT NULL 
2. customer does not have an open order (meaning he does not have an order with amount paid of 0.00)
3. payment_type_id is associated with the customer_id correctly

PATCH Ability to update order info:
1. payment_type_id update if: payment_type_id is associated with the customer_id correctly
2. amount_paid update if: amount_paid = total amount of order

DELETE Ability to remove order

